### PR TITLE
Add DocRaptor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 List of tools for dealing with the wonderful PDF format.
 
+## API
+- [DocRaptor](https://docraptor.com) - Based on Prince, with libraries in PHP, Python, Node.js, Ruby, Java, and .NET
+
 ## C
 
 - [PdfiumViewer](https://github.com/pvginkel/PdfiumViewer)


### PR DESCRIPTION
DocRaptor's an API version of Princely (with a lot more features and support), though I thought adding an API section would be better than linking to all the individual DocRaptor libraries.