### PR TITLE
Add PDFBolt to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ List of tools for dealing with the wonderful PDF format.
 
 ## API
 - [DocRaptor](https://docraptor.com) - Based on Prince, with libraries in PHP, Python, Node.js, Ruby, Java, and .NET
+- [PDFBolt](https://pdfbolt.com/docs) - HTML to PDF conversion API with Chromium rendering, templates, and AI generation
 
 ## C
 


### PR DESCRIPTION
Adding PDFBolt to the API section alongside DocRaptor. PDFBolt is an HTML to PDF conversion API built on headless Chromium with support for templates and AI-powered document generation.