### PR TITLE
Add PDFGem to Online PDF Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ List of tools for dealing with the wonderful PDF format.
 
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
+- [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.
+
 ## HASKELL
 
 - [toolbox](https://github.com/Yuras/pdf-toolbox)


### PR DESCRIPTION
## What

Adds [PDFGem](https://pdfgem.io) to the **Online PDF Tools** section.

## About PDFGem

- **28 free browser-based PDF tools**: merge, split, compress, convert (Word, Excel, PPT, JPG), edit, fill forms, redact, read, reorder pages, and more
- **Privacy-first**: all processing runs client-side in the browser — no files are uploaded to any server
- **No account required**: no signup, no login, no data collection
- **16 languages**: English, Spanish, French, German, Portuguese, Japanese, Korean, Chinese, Russian, Turkish, Italian, Indonesian, Vietnamese, and more
- **Built with**: PDF.js, pdf-lib, and modern browser APIs

PDFGem fits well alongside AllInOneTools and MiOffice as a privacy-focused, browser-based PDF tool suite.