### PR TITLE
Add PDFKit — free client-side PDF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ List of tools for dealing with the wonderful PDF format.
 
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
+- [PDFKit](https://pdfkit.davrapps.dev) – Free online PDF tools: merge, split, compress, rotate PDFs and convert between PDF and images. 100% client-side — files never leave the browser. No signup required.
+
 ## HASKELL
 
 - [toolbox](https://github.com/Yuras/pdf-toolbox)


### PR DESCRIPTION
Added [PDFKit](https://pdfkit.davrapps.dev) to the Online PDF Tools section.

**What it does:** Merge, split, compress, rotate PDFs and convert between PDF and images. All processing happens 100% in the browser — no files are uploaded to any server.

**Why it fits:** Similar to existing entries (AllInOneTools, MiOffice), PDFKit is a privacy-first online PDF toolbox with no signup required.