### PR TITLE
Add PDFSpark to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ List of tools for dealing with the wonderful PDF format.
 ## API
 - [DocRaptor](https://docraptor.com) - Based on Prince, with libraries in PHP, Python, Node.js, Ruby, Java, and .NET
 - [PDFBolt](https://pdfbolt.com/docs) - HTML to PDF conversion API with Chromium rendering, templates, and AI generation
+- [PDFSpark](https://pdfspark.dev) - Free PDF generation API
 
 ## C
 


### PR DESCRIPTION
## Summary

- Adds [PDFSpark](https://pdfspark.dev) to the API section - a free PDF generation API

Follows the existing format used by other entries in the API section.