### PR TITLE
Add questio to PYTHON section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ List of tools for dealing with the wonderful PDF format.
 
 - [doc2text](https://github.com/jlsutherland/doc2text)
 
+- [questio](https://github.com/abcreativ/questio)
+
 ## OCAML
 
 - [caradoc](https://github.com/ANSSI-FR/caradoc)


### PR DESCRIPTION
Adds [questio](https://github.com/abcreativ/questio) to the PYTHON section.

questio is a forensic PDF auditor CLI for detecting edited, forged, or tampered PDFs. Python 3.10+, MIT licensed, pip-installable, runs locally.

Entry format matches existing entries in the section.