### PR TITLE
Add RedaktPDF to Online PDF Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ List of tools for dealing with the wonderful PDF format.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
 - [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.
+- [RedaktPDF](https://redaktpdf.com) – Privacy-first online PDF editor with permanent object-level redaction (not overlay), end-to-end encryption (AES-256-GCM in-browser), text and page editing, and auto-delete retention. No sign-up required for first use.
 
 ## HASKELL
 


### PR DESCRIPTION
Adding RedaktPDF to the Online PDF Tools section.

Unique angle vs the existing entries in that section:

- **Permanent object-level redaction** — strips content from the PDF content stream, not a visual overlay. Redacted text cannot be recovered via copy-paste, search, or PDF parsing.
- **End-to-end encryption** — files are encrypted in the browser with AES-256-GCM before upload for signed-in users. Server only ever handles ciphertext.
- **Auto-delete TTL** — uploaded files are purged automatically (2 h anonymous, 24 h free, 7 d Pro, 30 d Business).
- **No sign-up for first use** — drag a PDF, edit, download. No account gate on the first document.

Alphabetically placed after PDFGem.