### PR TITLE
Add NoCodeVista PDF Tools to Online PDF Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ List of tools for dealing with the wonderful PDF format.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
 - [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.
-- [NoCodeVista PDF Tools](https://nocodevista.com) – Free browser-based PDF tools including compress, merge, split, edit, PDF to JPG, and JPG to PDF. No login required, works entirely in the browser.
+- [NoCodeVista PDF Tools](https://nocodevista.com/tools/pdf-tools) – Free browser-based PDF tools including compress, merge, split, edit, PDF to JPG, and JPG to PDF. No login required, works entirely in the browser.
 
 ## HASKELL
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ List of tools for dealing with the wonderful PDF format.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
 - [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.
+- [NoCodeVista PDF Tools](https://nocodevista.com) – Free browser-based PDF tools including compress, merge, split, edit, PDF to JPG, and JPG to PDF. No login required, works entirely in the browser.
 
 ## HASKELL
 


### PR DESCRIPTION
Adding [NoCodeVista PDF Tools](https://nocodevista.com) to the `## Online PDF Tools` section.

NoCodeVista offers free browser-based PDF tools including:
- Compress PDF
- Merge PDF
- Split PDF
- Edit PDF
- PDF to JPG
- JPG to PDF

All tools work entirely in the browser with no login required — consistent with other entries in this section.