### PR TITLE
Add PDF Mavericks — browser-only PDF toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ List of tools for dealing with the wonderful PDF format.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
 - [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.
+- [PDF Mavericks](https://www.pdfmavericks.com) - Browser-based PDF toolkit. 25+ tools (merge, split, compress, convert, rotate, sign, unlock, reorder, OCR-to-text, Aadhaar mask). No uploads, no signup, free.
 
 ## HASKELL
 


### PR DESCRIPTION
PDF Mavericks (https://www.pdfmavericks.com) is a free browser-based PDF toolkit with 25+ tools: merge, split, compress, rotate, convert, sign, unlock, reorder pages, PDF-to-text, PDF-to-markdown, PDF-to-CSV, Aadhaar masking, and more.

All processing runs client-side via WebAssembly. Files never leave the browser — no upload, no server, no account required. Supports files up to 100MB.

The codebase is Next.js. No backend file handling: zero upload surface, which is why it fits alongside the other browser-only entries in this section.

I am the maintainer. Happy to answer questions or adjust the description to match your preferred format.