### PR TITLE
Add AllPDFMagic to Online PDF Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ List of tools for dealing with the wonderful PDF format.
 
 - [printer](https://github.com/strzibny/invoice_printer)
 
-- [PyMuPDF](https://github.com/pymupdf/PyMuPDF)
-
 - [inspector](https://github.com/prawnpdf/pdf-inspector)
 
 - [princely](https://github.com/mbleigh/princely)
@@ -127,6 +125,8 @@ List of tools for dealing with the wonderful PDF format.
 - [open-paperless](https://github.com/zhoubear/open-paperless)
 
 - [PyPDF2](https://github.com/mstamy2/PyPDF2)
+
+- [PyMuPDF](https://github.com/pymupdf/PyMuPDF)
 
 - [WeasyPrint](https://github.com/Kozea/WeasyPrint)
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ List of tools for dealing with the wonderful PDF format.
 
 - [caradoc](https://github.com/ANSSI-FR/caradoc)
 
+## Online PDF Tools
+- [AllInOneTools](https://allinonetools.net/pdf-tools) – Privacy-first online PDF tools to convert, compress, merge, and edit PDFs directly in the browser (no uploads, no sign-up).
+
 ## HASKELL
 
 - [toolbox](https://github.com/Yuras/pdf-toolbox)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 List of tools for dealing with the wonderful PDF format.
 
+## API
+- [DocRaptor](https://docraptor.com) - Based on Prince, with libraries in PHP, Python, Node.js, Ruby, Java, and .NET
+
 ## C
 
 - [PdfiumViewer](https://github.com/pvginkel/PdfiumViewer)

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ List of tools for dealing with the wonderful PDF format.
 
 - [snappy](https://github.com/KnpLabs/snappy)
 
-- [laravel](pdf https://github.com/niklasravnsborg/laravel-pdf)
+- [laravel pdf](https://github.com/niklasravnsborg/laravel-pdf)
 
 - [dompdf](https://github.com/dompdf/dompdf)
 
-- [laravel](dompdf https://github.com/barryvdh/laravel-dompdf)
+- [laravel dompdf] (https://github.com/barryvdh/laravel-dompdf)
 
 - [html2pdf](https://github.com/spipu/html2pdf)
 
-- [pdf](to-image https://github.com/spatie/pdf-to-image)
+- [pdf to-image](https://github.com/spatie/pdf-to-image)
 
 - [FPDF](https://github.com/Setasign/FPDF)
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ List of tools for dealing with the wonderful PDF format.
 ## Online PDF Tools
 - [AllInOneTools](https://allinonetools.net/pdf-tools) – Privacy-first online PDF tools to convert, compress, merge, and edit PDFs directly in the browser (no uploads, no sign-up).
 
+- [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
+
 ## HASKELL
 
 - [toolbox](https://github.com/Yuras/pdf-toolbox)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ List of tools for dealing with the wonderful PDF format.
 
 - [printer](https://github.com/strzibny/invoice_printer)
 
+- [PyMuPDF](https://github.com/pymupdf/PyMuPDF)
+
 - [inspector](https://github.com/prawnpdf/pdf-inspector)
 
 - [princely](https://github.com/mbleigh/princely)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ List of tools for dealing with the wonderful PDF format.
 
 - [dompdf](https://github.com/dompdf/dompdf)
 
-- [laravel dompdf] (https://github.com/barryvdh/laravel-dompdf)
+- [laravel dompdf](https://github.com/barryvdh/laravel-dompdf)
 
 - [html2pdf](https://github.com/spipu/html2pdf)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ List of tools for dealing with the wonderful PDF format.
 
 ## API
 - [DocRaptor](https://docraptor.com) - Based on Prince, with libraries in PHP, Python, Node.js, Ruby, Java, and .NET
+- [PDFBolt](https://pdfbolt.com/docs) - HTML to PDF conversion API with Chromium rendering, templates, and AI generation
 
 ## C
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ List of tools for dealing with the wonderful PDF format.
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools to merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF. No signup required.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
+- [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.
+
 ## HASKELL
 
 - [toolbox](https://github.com/Yuras/pdf-toolbox)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ List of tools for dealing with the wonderful PDF format.
 
 ## Online PDF Tools
 - [AllInOneTools](https://allinonetools.net/pdf-tools) – Privacy-first online PDF tools to convert, compress, merge, and edit PDFs directly in the browser (no uploads, no sign-up).
-
+- [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools to merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF. No signup required.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
 ## HASKELL

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ List of tools for dealing with the wonderful PDF format.
 
 ## Online PDF Tools
 - [AllInOneTools](https://allinonetools.net/pdf-tools) – Privacy-first online PDF tools to convert, compress, merge, and edit PDFs directly in the browser (no uploads, no sign-up).
+- [AllPDFMagic](https://allpdfmagic.com) – 33+ free online PDF tools with AI workflows. Merge, compress, convert, edit, sign, and protect PDFs — no signup required, no daily limits.
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools to merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF. No signup required.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 


### PR DESCRIPTION
Add [AllPDFMagic](https://allpdfmagic.com) — a free online PDF toolbox with 33+ tools including AI-powered workflows, no signup required, and no daily limits.

This is a perfect fit for the 'Online PDF Tools' section.