### PR TITLE
Add FileLume to online PDF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ List of tools for dealing with the wonderful PDF format.
 ## Online PDF Tools
 - [AllInOneTools](https://allinonetools.net/pdf-tools) – Privacy-first online PDF tools to convert, compress, merge, and edit PDFs directly in the browser (no uploads, no sign-up).
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools to merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF. No signup required.
+- [FileLume](https://filelume.com) – Browser-based PDF tools for merging, splitting, converting, and preparing files. Supported workflows process locally where technically possible, and each tool labels whether processing is local, server-based, or hybrid.
 - [MiOffice](https://mioffice.ai) – AI office suite with 66+ browser-based applications for PDF conversion, compression, merging, splitting, and document scanning. All processing runs client-side via WebAssembly — documents never leave the device.
 
 - [PDFGem](https://pdfgem.io) – Free privacy-first suite of 28 browser-based PDF tools (merge, split, compress, convert, edit, fill forms, redact, read). All processing runs client-side — no uploads, no account required. Supports 16 languages.


### PR DESCRIPTION
## Addition

Adds FileLume to the Online PDF Tools section.

FileLume provides browser-based PDF, image, audio and data utilities. Supported workflows process locally in the browser where technically possible, and each tool discloses whether processing is local, server-based or hybrid.

## Fit

- Matches the existing Online PDF Tools section.
- Uses the existing list entry format.
- No unrelated files were changed.

Disclosure: I am associated with FileLume.